### PR TITLE
Remove need for tslib at runtime

### DIFF
--- a/examples/kinesis-background-writer.ts
+++ b/examples/kinesis-background-writer.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
-import * as kinesis from '@aws-sdk/client-kinesis';
+import { KinesisClient, PutRecordsCommand, PutRecordsCommandInput } from '@aws-sdk/client-kinesis';
 import { KinesisBackgroundWriter, KinesisRetrier } from '@shutterstock/kinesis-helpers';
 
-const kinesisClient = new kinesis.KinesisClient({});
+const kinesisClient = new KinesisClient({});
 const { KINESIS_STREAM_NAME = 'kinesis-helpers-test-stream', RECORDS_TO_WRITE = '40000' } =
   process.env;
 const RECORDS_TO_WRITE_NUM = parseInt(RECORDS_TO_WRITE, 10);
@@ -20,7 +20,7 @@ async function main() {
     concurrency: 4,
   });
 
-  const records: kinesis.PutRecordsCommandInput = {
+  const records: PutRecordsCommandInput = {
     StreamName: KINESIS_STREAM_NAME,
     Records: [],
   };
@@ -43,7 +43,7 @@ async function main() {
   for (let i = 0; i < RECORDS_TO_WRITE_NUM; i += RECORDS_PER_BATCH) {
     // Note how many records we are adding and how long it took
     console.time(`Adding ${i} to ${i + RECORDS_PER_BATCH} records took`);
-    await backgroundWriter.send(new kinesis.PutRecordsCommand(records));
+    await backgroundWriter.send(new PutRecordsCommand(records));
     console.timeEnd(`Adding ${i} to ${i + RECORDS_PER_BATCH} records took`);
   }
 

--- a/examples/kinesis-retrier.ts
+++ b/examples/kinesis-retrier.ts
@@ -1,15 +1,15 @@
 /* eslint-disable no-console */
-import * as kinesis from '@aws-sdk/client-kinesis';
+import { KinesisClient, PutRecordsCommand, PutRecordsCommandInput } from '@aws-sdk/client-kinesis';
 import { KinesisRetrierStatic } from '@shutterstock/kinesis-helpers';
 
-const kinesisClient = new kinesis.KinesisClient({});
+const kinesisClient = new KinesisClient({});
 const { KINESIS_STREAM_NAME = 'kinesis-helpers-test-stream', RECORDS_TO_WRITE = '10000' } =
   process.env;
 const RECORDS_TO_WRITE_NUM = parseInt(RECORDS_TO_WRITE, 10);
 const RECORDS_PER_BATCH = 500;
 
 async function main() {
-  const records: kinesis.PutRecordsCommandInput = {
+  const records: PutRecordsCommandInput = {
     StreamName: KINESIS_STREAM_NAME,
     Records: [],
   };
@@ -34,7 +34,7 @@ async function main() {
     console.time(`Adding ${i} to ${i + RECORDS_PER_BATCH} records took`);
     const result = await KinesisRetrierStatic.putRecords(
       kinesisClient,
-      new kinesis.PutRecordsCommand(records),
+      new PutRecordsCommand(records),
     );
     console.timeEnd(`Adding ${i} to ${i + RECORDS_PER_BATCH} records took`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@shutterstock/p-map-iterable": "^1.0.11"
+        "@shutterstock/p-map-iterable": "^1.1.0"
       },
       "devDependencies": {
         "@types/jest": "29.5.2",
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/@shutterstock/p-map-iterable": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@shutterstock/p-map-iterable/-/p-map-iterable-1.0.11.tgz",
-      "integrity": "sha512-SiTKiCol8bFCZaHZUYV7lWZLEUYeaO0OdyandyAw1vCvsKJtbJ3jPcDgcpqkK1SfgA/3cNrPnp6d5kk4EacZkQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@shutterstock/p-map-iterable/-/p-map-iterable-1.1.0.tgz",
+      "integrity": "sha512-tjCAxHoyzoA2jQzQ00uorsDVxzRUACP+MUpRDYZ0of9ZCqygskliH1NxOQBCIlKjHY602+4u/HyBc5SHlYwGtQ==",
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -8381,9 +8381,9 @@
       }
     },
     "@shutterstock/p-map-iterable": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@shutterstock/p-map-iterable/-/p-map-iterable-1.0.11.tgz",
-      "integrity": "sha512-SiTKiCol8bFCZaHZUYV7lWZLEUYeaO0OdyandyAw1vCvsKJtbJ3jPcDgcpqkK1SfgA/3cNrPnp6d5kk4EacZkQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@shutterstock/p-map-iterable/-/p-map-iterable-1.1.0.tgz",
+      "integrity": "sha512-tjCAxHoyzoA2jQzQ00uorsDVxzRUACP+MUpRDYZ0of9ZCqygskliH1NxOQBCIlKjHY602+4u/HyBc5SHlYwGtQ==",
       "requires": {
         "aggregate-error": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@shutterstock/p-map-iterable": "^1.0.11"
+    "@shutterstock/p-map-iterable": "^1.1.0"
   },
   "peerDependencies": {
     "@aws-sdk/client-kinesis": "^3.41.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,10 @@
     "sourceMap": true,
     "resolveJsonModule": true,
 
-    "importHelpers": true,
+    "importHelpers": false,
+    "noEmitHelpers": true,
     "composite": true,
-    "target": "es2016",
+    "target": "es2018",
     "module": "commonjs",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Note: AWS SDK v3 still needs tslib, so this does not entirely remove the need, but it does help prevent conflicts or duplicate deps.